### PR TITLE
Change UI reset to only occur on item type change

### DIFF
--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -613,7 +613,7 @@ document.addEventListener("DOMContentLoaded", function () {
             document.getElementById('trials').value = 1000;
         }
     })
-    $('select').on('change', function() {
+    $('#item_type').on('change', function() {
         if (document.getElementById("tyrant").selected){
             //enable AEE checkbox to be clicked
             document.getElementById('AEE').disabled = false;


### PR DESCRIPTION
This PR changes the UI so that the settings only reset to defaults when you change between normal and tyrant starforcing (instead of when you change any select element)