### PR TITLE
Add server selector for starforcing calc

### DIFF
--- a/starforceCalculator/index.html
+++ b/starforceCalculator/index.html
@@ -105,6 +105,16 @@
             </div>
 
             <div class="col-sm-12 containOne">
+                <p>Server: <select id="server">
+                    <option value="gms">GMS</option>
+                    <option value="kms">KMS/JMS/MapleSEA</option>
+                    <option value="tms">TMS</option>
+                    <option value="tmsr">TMS Reboot</option>
+                </select>
+                </p>
+            </div>
+
+            <div class="col-sm-12 containOne">
                 <p>Event:
                     <label class="checkbox">
                         <input type="checkbox" id="5_10_15" name="5_10_15" value="5_10_15" />


### PR DESCRIPTION
This PR adds a server selector to the starforcing calculator so people can compare prices between the various servers (useful for current discussions surrounding the boycott).