### PR TITLE
Correct class data

### DIFF
--- a/LegionCalculator/src/hyper.js
+++ b/LegionCalculator/src/hyper.js
@@ -2121,11 +2121,11 @@ function determineNumberofLines(combination, stat) {
 function getClassData(maple_class) {
     var class_data = {
         'Adele': {
-            'attPercent': 14,
-            'iedPercent': [20, 20, 10, 10, 5, 5, 5],
-            'dmgPercent': 20,
-            'bossPercent': 0,
-            'critDmg': 0
+            'attPercent': 14, // 10% from Recalling Greatness + 4% from Echo of Hero
+            'iedPercent': [20, 10, 10, 5, 5], // Ruination (20%) + Noble Summons (10%) + Grave Proclamation (10%) + Resonance Rush x2 (2 * 5%) 
+            'dmgPercent': 22, // 20% from Grave Proclamation + level 2 link skill (2% per pt member)
+            'bossPercent': 14, // 10% from Strive + level 2 link skill
+            'critDmg': 10 // 10% from Recalling Greatness
         },
 
         'Angelic Buster': {

--- a/hyperCalculator/main.js
+++ b/hyperCalculator/main.js
@@ -2031,11 +2031,11 @@ function determineNumberofLines(combination, stat) {
 function getClassData(maple_class) {
     var class_data = {
         'Adele': {
-            'attPercent': 14,
-            'iedPercent': [20, 20, 10, 10, 5, 5, 5],
-            'dmgPercent': 20,
-            'bossPercent': 0,
-            'critDmg': 0
+            'attPercent': 14, // 10% from Recalling Greatness + 4% from Echo of Hero
+            'iedPercent': [20, 10, 10, 5, 5], // Ruination (20%) + Noble Summons (10%) + Grave Proclamation (10%) + Resonance Rush x2 (2 * 5%) 
+            'dmgPercent': 22, // 20% from Grave Proclamation + level 2 link skill (2% per pt member)
+            'bossPercent': 14, // 10% from Strive + level 2 link skill
+            'critDmg': 10 // 10% from Recalling Greatness
         },
 
         'Angelic Buster': {

--- a/statEquivalentCalculator/main.js
+++ b/statEquivalentCalculator/main.js
@@ -2115,11 +2115,11 @@ function determineNumberofLines(combination, stat) {
 function getClassData(maple_class) {
     var class_data = {
         'Adele': {
-            'attPercent': 14,
-            'iedPercent': [20, 20, 10, 10, 5, 5, 5],
-            'dmgPercent': 20,
-            'bossPercent': 0,
-            'critDmg': 0
+            'attPercent': 14, // 10% from Recalling Greatness + 4% from Echo of Hero
+            'iedPercent': [20, 10, 10, 5, 5], // Ruination (20%) + Noble Summons (10%) + Grave Proclamation (10%) + Resonance Rush x2 (2 * 5%) 
+            'dmgPercent': 22, // 20% from Grave Proclamation + level 2 link skill (2% per pt member)
+            'bossPercent': 14, // 10% from Strive + level 2 link skill
+            'critDmg': 10 // 10% from Recalling Greatness
         },
 
         'Angelic Buster': {


### PR DESCRIPTION
@brendonmay Poking through the source there's a few things I don't understand: It seems there are some inconsistencies on how class data is handled, notably:
- Should Echo of Hero really be counted for in attPercent? It's not a guaranteed 100% uptime buff, and isn't used in calculating BAs.
- A class's own link skill does not seem to be factored in (for every class, at least). Adele's link skill is currently not accounted for. I believe we should account for the highest level link skill for the class (mage link might be wonky, not sure how we should handle). 
- Only a couple classes have crit damage accounted for despite having passive crit damage

In my patch to add Lara and Kain support (#25), I account for crit damage and Lara's own link skill. This doesn't seem to be the norm, and I think we should set consistent stances on each of the points I've mentioned. I haven't made any other class changes other than Adele because I want to receive some feedback on the listed bullet points.

~~On a side note, I believe Adele's IED calculation is incorrect. I'm really not sure where the extra 20% and 5% bonuses are coming from. I welcome opinions across the board, I think we can get slightly more accurate numbers with correct class data.~~ I have since realized that the 20% came from nodes, and the 5% came from CRA.