### PR TITLE
Add ignition starforce prices

### DIFF
--- a/starforceCalculator/index.html
+++ b/starforceCalculator/index.html
@@ -112,8 +112,7 @@
 
             <div class="col-sm-12 containOne">
                 <p>Server: <select id="server">
-                    <option value="gms">GMS</option>
-                    <option value="kms">KMS/JMS/MapleSEA</option>
+                    <option value="kms">GMS/KMS/JMS/MapleSEA</option>
                     <option value="tms">TMS</option>
                     <option value="tmsr">TMS Reboot</option>
                 </select>

--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -97,19 +97,8 @@ function kmsCost(current_star, item_level) {
 
 function gmsCost(current_star, item_level) {
     // The GMS starforce changes in Destiny just multiplied the costs by 0.78 for all the parts where we were paying extra.
-    if (current_star >= 20) {
-        return 0.78 * (1000 + item_level ** 3 * ((current_star + 1) ** 2.7) / 100);
-    }
-    if (current_star >= 18) {
-        return 0.78 * (1000 + item_level ** 3 * ((current_star + 1) ** 2.7) / 110);
-    }
-    if (current_star >= 15) {
-        return 0.78 * (1000 + item_level ** 3 * ((current_star + 1) ** 2.7) / 120);
-    }
-    if (current_star >= 10) {
-        return 1000 + item_level ** 3 * ((current_star + 1) ** 2.7) / 400;
-    }
-    return 1000 + item_level ** 3 * (current_star + 1) / 25;
+    // In ignition they just gave us KMS prices.
+    return kmsCost(current_star, item_level);
 }
 
 function tmsRegCost(current_star, item_level) {

--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -95,12 +95,6 @@ function kmsCost(current_star, item_level) {
     return 1000 + item_level ** 3 * (current_star + 1) / 25;
 }
 
-function gmsCost(current_star, item_level) {
-    // The GMS starforce changes in Destiny just multiplied the costs by 0.78 for all the parts where we were paying extra.
-    // In ignition they just gave us KMS prices.
-    return kmsCost(current_star, item_level);
-}
-
 function tmsRegCost(current_star, item_level) {
     if (current_star >= 20) {
         return 1000 + item_level ** 3 * ((current_star + 1) ** 2.7) / 40;
@@ -123,8 +117,8 @@ function tmsRebootCost(current_star, item_level) {
 }
 
 // Map from server input value to the associated cost function.
+// As of the ignition update GMS uses KMS starforce prices.
 const SERVER_COST_FUNCTIONS = {
-    "gms": gmsCost,
     "kms": kmsCost,
     "tms": tmsRegCost,
     "tmsr": tmsRebootCost,


### PR DESCRIPTION
This PR updates the calculator with the new GMS starforce prices. Specifically, it merges the GMS option with the KMS/JMS/MapleSEA option since it's all the same now.