### PR TITLE
add 15-16 safeguard feature

### DIFF
--- a/starforceCalculator/index.html
+++ b/starforceCalculator/index.html
@@ -91,6 +91,7 @@
                 </p>
                 <p>Safeguard: <select id="safeguard">
                         <option value="yes">Safeguard</option>
+                        <option value="15_16">Only 15 and 16</option>
                         <option value="no">No safeguard</option>
                     </select>
                 </p>


### PR DESCRIPTION
Only the 15th and 16th star will be safeguarded.
This feature is particularly useful for calculations ending above 17* but doesn't do anything you can't already calculate at 17* or below.