### PR TITLE
Fix label on level 120-139 option

### DIFF
--- a/flameCalculator/updateOptions.js
+++ b/flameCalculator/updateOptions.js
@@ -32,7 +32,7 @@ function updateItemLevels(maple_class) {
         $itemLevel.append("<option value='250+'>250+</option>")
     }
     else {
-        $itemLevel.append("<option value='120-139'>140-159</option>")
+        $itemLevel.append("<option value='120-139'>120-139</option>")
         $itemLevel.append("<option value='140-159'>140-159</option>")
         $itemLevel.append("<option value='160-179'>160-179</option>")
         $itemLevel.append("<option value='180-199'>180-199</option>")


### PR DESCRIPTION
This PR fixes the label on the 120-139 level range option added by switching from weapon back to armor.