### PR TITLE
update cubing data scraper to write results directly to cubeRates.js instead of manually copying from json file 

### DIFF
--- a/cubingCalculator/cubeRates.js
+++ b/cubingCalculator/cubeRates.js
@@ -1,3 +1,4 @@
+// Auto-generated on 11/14/2023
 const cubeRates = {
     "lvl120to200": {
         "secondary": {

--- a/cubingCalculator/cubing_data_scraper/README.md
+++ b/cubingCalculator/cubing_data_scraper/README.md
@@ -7,32 +7,31 @@ To install dependencies, run:
 ```
 pip install -r requirements.txt --user
 ```
-Note: remember to omit the `--user` flag if running from a virtual environment.
+Note: omit the `--user` flag if running from a virtual environment.
 
 ### Running the scraper
 To run with the default configuration:
 ```
 ./cubing_data_scrapyer.py
 ```
-The output file with the formatted data is located at: `data/formatted_data.json`
+Cubing data will be written to `cubeRates.js` which is used by the calculator scripts.\
+Raw data (html and json files) will be stored in: `cubing_data_scraper/data/`
 
 > Notes:
+> - All existing content in `cubeRates.js` will be overwritten.
+> - This default configuration will issue requests for items types, cubes, and tiers that are currently supported by the calculator.\
+> At the time of writing, this will make 140 requests and save each into a separate html file so it can take several minutes.
 >
-> 1. This default configuration will issue requests for items types, cubes, and tiers that are currently supported by the calculator.
-At the time of writing, this will make 140 requests and save each into a separate html file so it can take several minutes.
->
-> 2. For now we are just manually copying and pasting the contents from `formatted_data.json` into the file: `cubingRates.js` but we should come up with a better solution.
 
 ### Current steps for updating cubing rates
 1. Run the script and dump results (ideally into a separate data folder by date)
 ```
 ./cubing_data_scrapyer.py -o data_<DD-MM-YY>
 ```
-2. Check for any un-translated lines in output debug messages. If we need to make changes to processing scripts, re-run on cached html files with `-c`:
+2. Check for any un-translated lines in output debug messages. If we need to make changes to processing scripts, re-run on cached html files in the same data folder with `-c`:
 ```
 ./cubing_data_scrapyer.py -c -o data_<DD-MM-YY>
 ```
-3. Set the value of `cubeRates` in `cubingRates.js` to the contents from `cubing_data_scraper/data_<DD-MM-YY>/formatted_data.json`. Paste the contents immediately following `const cubeRates =`
 
 ---
 

--- a/cubingCalculator/cubing_data_scraper/cubing_data_scraper.py
+++ b/cubingCalculator/cubing_data_scraper/cubing_data_scraper.py
@@ -36,6 +36,10 @@ def main(output_dir, use_cached):
     data_source_dir = os.path.abspath(output_dir)
     html_files_dir = os.path.join(data_source_dir, "html_files")
 
+    print("This script will overwrite the contents of: {}".format(CUBE_DATA_JS_PATH))
+    print("Raw data will be stored in: {}".format(data_source_dir))
+    print()
+
     if use_cached:
         print("Looking for cached html files in: {}".format(html_files_dir))
         html_files = glob.glob(os.path.join(html_files_dir, "*.html"))
@@ -47,6 +51,7 @@ def main(output_dir, use_cached):
         # send HTTP requests for cubing data and download html files
         print("Preparing to send HTTP requests to Nexon's website for cubing data...")
         html_files = requester.download_html_files(html_files_dir)
+    print()
 
     # parse html files and extract all data into a single json file
     print("Parsing html files to generate raw json. Convert strings from korean to english...")

--- a/cubingCalculator/cubing_data_scraper/cubing_data_scraper.py
+++ b/cubingCalculator/cubing_data_scraper/cubing_data_scraper.py
@@ -8,6 +8,7 @@ import argparse
 import glob
 import json
 import datetime
+from collections import OrderedDict
 
 # internal modules
 from lib import requester, htmlparser, dataformatter
@@ -66,9 +67,8 @@ def main(output_dir, use_cached):
     # this is a hack to store data in a way that's accessible from the calculator script
     # i'd like to be able to access it directly from json or other static data file but not sure how
     print("Writing data to: {}".format(CUBE_DATA_JS_PATH))
-    formatted_data = None
     with open(output_file, "r") as fh:
-        formatted_data = json.dumps(json.load(fh), indent=4)
+        formatted_data = json.dumps(json.load(fh, object_pairs_hook=OrderedDict), indent=4)
     
     with open(CUBE_DATA_JS_PATH, "w") as fh:
         fh.write("// Auto-generated on {}\n".format(datetime.date.today().strftime("%m/%d/%Y")))

--- a/cubingCalculator/cubing_data_scraper/cubing_data_scraper.py
+++ b/cubingCalculator/cubing_data_scraper/cubing_data_scraper.py
@@ -6,13 +6,15 @@ import os
 import sys
 import argparse
 import glob
+import json
+import datetime
 
 # internal modules
 from lib import requester, htmlparser, dataformatter
 
 PARENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_DATA_PATH = os.path.join(PARENT_DIR, "data")
-
+CUBE_DATA_JS_PATH = os.path.join(os.path.dirname(PARENT_DIR), "cubeRates.js")
 
 # setting this up in case we add more options in the future
 def parse_arguments():
@@ -53,7 +55,22 @@ def main(output_dir, use_cached):
     # extract pieces of interest from full dataset
     # process and format data into useful structure
     print("Generate formatted json file for calculator scripts...")
-    dataformatter.format_cubing_data(raw_json_file, data_source_dir)
+    output_file = dataformatter.format_cubing_data(raw_json_file, data_source_dir)
+
+    # write the contents of formatted json file to cubeRates.js
+    # this is a hack to store data in a way that's accessible from the calculator script
+    # i'd like to be able to access it directly from json or other static data file but not sure how
+    print("Writing data to: {}".format(CUBE_DATA_JS_PATH))
+    formatted_data = None
+    with open(output_file, "r") as fh:
+        formatted_data = json.dumps(json.load(fh), indent=4)
+    
+    with open(CUBE_DATA_JS_PATH, "w") as fh:
+        fh.write("// Auto-generated on {}\n".format(datetime.date.today().strftime("%m/%d/%Y")))
+        fh.write("const cubeRates = ")
+        fh.write(formatted_data)
+    
+    print("Done.")
 
 
 if __name__ == "__main__":

--- a/cubingCalculator/cubing_data_scraper/lib/dataformatter.py
+++ b/cubingCalculator/cubing_data_scraper/lib/dataformatter.py
@@ -132,6 +132,7 @@ def format_rates_list(potential_lines_list):
 
 # format raw data for easier parsing by javascript files, save it as a json
 # each entry is stored as a tuple with format: (category, value, rate as float)
+# returns path to output file
 def format_cubing_data(raw_json_file, output_dir):
     with open(raw_json_file, "r") as fh:
         raw_data_dictionary = json.load(fh)
@@ -175,6 +176,7 @@ def format_cubing_data(raw_json_file, output_dir):
         f.write(full_dump)
 
     print("Finished writing formatted json file: {}".format(full_formatted_data_file))
+    return full_formatted_data_file
 
 
 if __name__ == "__main__":

--- a/cubingCalculator/cubing_data_scraper/lib/dataformatter.py
+++ b/cubingCalculator/cubing_data_scraper/lib/dataformatter.py
@@ -3,6 +3,7 @@
 import re
 import json
 import os
+from collections import OrderedDict
 
 
 def _str_percent_to_float(percent_string):
@@ -139,25 +140,25 @@ def format_cubing_data(raw_json_file, output_dir):
 
     # structure is: lvl range -> item type -> cube type -> item tier -> line number -> list of rates
     # "list of rates" is the portion that will be formatted. hierarchy matches the raw dictionary otherwise.
-    formatted_data = {}
+    formatted_data = OrderedDict()
 
     # keep track of lines that did not match any regex patterns for debugging
     full_error_list = []
 
     for (level_range, item_type_data) in raw_data_dictionary.items():
-        formatted_data[level_range] = {}
+        formatted_data[level_range] = OrderedDict()
 
         for (item_type, cube_data) in item_type_data.items():
-            formatted_data[level_range][item_type] = {}
+            formatted_data[level_range][item_type] = OrderedDict()
 
             for (cube_type, item_tier_data) in cube_data.items():
-                formatted_data[level_range][item_type][cube_type] = {}
+                formatted_data[level_range][item_type][cube_type] = OrderedDict()
 
                 for (item_tier, line_data) in item_tier_data.items():
-                    formatted_data[level_range][item_type][cube_type][item_tier] = {}
+                    formatted_data[level_range][item_type][cube_type][item_tier] = OrderedDict()
 
                     for (line_num, rates) in line_data.items():
-                        formatted_data[level_range][item_type][cube_type][item_tier][line_num] = {}
+                        formatted_data[level_range][item_type][cube_type][item_tier][line_num] = OrderedDict()
 
                         raw_potentials_list = raw_data_dictionary[level_range][item_type][cube_type][item_tier][line_num]
                         (formatted_rates, error_list) = format_rates_list(raw_potentials_list)

--- a/cubingCalculator/cubing_data_scraper/lib/htmlparser.py
+++ b/cubingCalculator/cubing_data_scraper/lib/htmlparser.py
@@ -1,9 +1,9 @@
 """Parse html files and extract raw cubing data into a combined json file."""
 
 from bs4 import BeautifulSoup
+from collections import OrderedDict
 import json
 import os
-
 
 from lib.translator import translate_text
 
@@ -22,7 +22,7 @@ class Parser:
 
     def __init__(self):
         self.current_html_data = None
-        self.data = {}
+        self.data = OrderedDict()
 
     def _load_html_file(self, html_file):
         with open(html_file) as fp:
@@ -44,17 +44,17 @@ class Parser:
         cube_type = chosen_options["cube_type"]
 
         if lvl_range not in self.data.keys():
-            self.data[lvl_range] = {}
+            self.data[lvl_range] = OrderedDict()
         if item_type not in self.data[lvl_range].keys():
-            self.data[lvl_range][item_type] = {}
+            self.data[lvl_range][item_type] = OrderedDict()
         if cube_type not in self.data[lvl_range][item_type].keys():
-            self.data[lvl_range][item_type][cube_type] = {}
+            self.data[lvl_range][item_type][cube_type] = OrderedDict()
 
         self.data[lvl_range][item_type][cube_type][tier] = self._parse_tables_potlines()
 
     # parse data from potentials table of this page
     def _parse_tables_potlines(self):
-        pot_rates = {}
+        pot_rates = OrderedDict()
 
         for table_class in self.LINE_NUMBER_TABLE_CLASSES:
             table_data = self.current_html_data.find("table", class_=table_class)
@@ -83,7 +83,7 @@ class Parser:
 # Additionally, the website has: 1) tier up information and 2) chance to roll a prime vs non-prime line
 # the implementation for parsing 2) is in scrape_tier_rates(), currently unused
 def scrape_tier_rates(page_data):
-    cube_rates_data = {}
+    cube_rates_data = OrderedDict()
 
     soup = BeautifulSoup(page_data.content, "html.parser")
 


### PR DESCRIPTION
Note: This doesn't affect the calculator in any way, just the cubing data scraper.

Currently, the cubing data scraper outputs data to a json file and we've been manually copying the text over to `cubeRates.js` which that the calculator actually uses (this is because we aren't sure how to get a js file to directly access a static json file).
Now the python script will write data to `cubeRates.js` directly, along with adding a comment at the top containing the date that the file was updated.

This is still not as ideal as having the js file somehow directly access static data properly but at least saves the manual copy/paste step after running the python script.