### PR TITLE
Add attack + any combo lines

### DIFF
--- a/cubingCalculator/getProbability.js
+++ b/cubingCalculator/getProbability.js
@@ -22,6 +22,7 @@ const emptyInputObject = {
     lineAutoSteal: 0,
     lineAttOrBoss: 0,
     lineAttOrBossOrIed: 0,
+    lineBossOrIed: 0,
 }
 
 // labels for categories used in json data reference and calculations
@@ -77,6 +78,7 @@ const INPUT_CATEGORY_MAP = {
     lineAutoSteal: [CATEGORY.AUTOSTEAL_PERC],
     lineAttOrBoss: [CATEGORY.ATT_PERC, CATEGORY.BOSSDMG_PERC],
     lineAttOrBossOrIed: [CATEGORY.ATT_PERC, CATEGORY.BOSSDMG_PERC, CATEGORY.IED_PERC],
+    lineBossOrIed: [CATEGORY.BOSSDMG_PERC, CATEGORY.IED_PERC],
 }
 
 // type of calculation can be total number of lines or a value sum (e.g. stat %, seconds of CDR)
@@ -112,6 +114,8 @@ const OUTCOME_MATCH_FUNCTION_MAP = {
         + _calculateTotal(outcome, CATEGORY.BOSSDMG_PERC)) >= requiredVal,
     lineAttOrBossOrIed: (outcome, requiredVal) => (_calculateTotal(outcome, CATEGORY.ATT_PERC)
         + _calculateTotal(outcome, CATEGORY.BOSSDMG_PERC)
+        + _calculateTotal(outcome, CATEGORY.IED_PERC)) >= requiredVal,
+    lineBossOrIed: (outcome, requiredVal) => (+ _calculateTotal(outcome, CATEGORY.BOSSDMG_PERC)
         + _calculateTotal(outcome, CATEGORY.IED_PERC)) >= requiredVal
 }
 

--- a/cubingCalculator/updateDesiredStatsOptions.js
+++ b/cubingCalculator/updateDesiredStatsOptions.js
@@ -156,7 +156,7 @@ function removeNormalStatOptions() {
     removeElementIfExists("statGroup");
 }
 
-function addCommonWSEOptions(itemLevel, desiredTier) {
+function addCommonWSEOptions(itemLevel, desiredTier, itemType) {
     const prime = getPrimeLineValue(itemLevel, desiredTier);
     const optionAmounts = get3LStatOptionAmounts(prime);
     addNormalOptionGroup("attack",
@@ -171,17 +171,41 @@ function addCommonWSEOptions(itemLevel, desiredTier) {
         "Attack and IED",
         "Attack With 1 Line of IED",
         IEDOptionAmounts);
+
+    const $desiredStats = $('#desiredStats');
+    // Hide boss for emblem or epic tier.
+    const showBoss = itemType !== "emblem" && desiredTier >= 2;
+    // These lines will calculate just fine for emblems too, but we still change the text to avoid confusion.
+    const shortAnyText = `(Attack${showBoss ? "/Boss" : ""}/IED)`;
+    const longAnyText = `Attack% ${showBoss ? "or Boss% " : ""}or IED`;
+
+    // Remove previous options in case user switched between WS and E.
+    removeElementIfExists("attackOrBossOrIedGroup");
+    removeElementIfExists("attackAndAnyGroup");
+
+    $desiredStats.append(`<optgroup id='attackOrBossOrIedGroup' label='Any Useful Lines ${shortAnyText}'></optgroup>`);
+    const $attackOrBossOrIedGroup = $('#attackOrBossOrIedGroup');
+    for (let i = 1; i <= 3; i++) {
+        $attackOrBossOrIedGroup.append(`<option id='labi${i}' value='lineAttOrBossOrIed+${i}'>${i} Line ${longAnyText}</option>`);
+    }
+
+    $desiredStats.append(`<optgroup id='attackAndAnyGroup' label='Attack + Any Useful Lines'></optgroup>`);
+    const $attackAndAnyGroup = $('#attackAndAnyGroup');
+    $attackAndAnyGroup.append(`<option id='lalabi' value='lineAtt+1&lineAttOrBossOrIed+2'>1 Line attack with 1 Line ${longAnyText}</option>`);
+    $attackAndAnyGroup.append(`<option id='la2labi' value='lineAtt+1&lineAttOrBossOrIed+3'>1 Line attack with 2 Line ${longAnyText}</option>`);
+    $attackAndAnyGroup.append(`<option id='2lalabi' value='lineAtt+2&lineAttOrBossOrIed+3'>2 Line attack with 1 Line ${longAnyText}</option>`);
 }
 
 function removeCommonWSEOptions() {
     removeElementIfExists("attackGroup");
     removeElementIfExists("attackAndIEDGroup");
+    removeElementIfExists("attackOrBossOrIedGroup");
+    removeElementIfExists("attackAndAnyGroup");
 }
 
 function removeCommonSEOptions() {
     removeElementIfExists("attackAndBossGroup");
     removeElementIfExists("attackOrBossGroup");
-    removeElementIfExists("attackOrBossOrIedGroup");
 }
 
 function addCommonSEOptions(itemLevel, desiredTier) {
@@ -216,12 +240,6 @@ function addCommonSEOptions(itemLevel, desiredTier) {
     const $attackOrBossGroup = $('#attackOrBossGroup');
     for (let i = 1; i <= 3; i++) {
         $attackOrBossGroup.append(`<option id='lab${i}' value='lineAttOrBoss+${i}'>${i} Line Attack% or Boss%</option>`);
-    }
-
-    $desiredStats.append(`<optgroup id='attackOrBossOrIedGroup' label='Attack or Boss Damage or IED'></optgroup>`);
-    const $attackOrBossOrIedGroup = $('#attackOrBossOrIedGroup');
-    for (let i = 1; i <= 3; i++) {
-        $attackOrBossOrIedGroup.append(`<option id='labi${i}' value='lineAttOrBossOrIed+${i}'>${i} Line Attack% or Boss% or IED</option>`);
     }
 }
 
@@ -370,7 +388,7 @@ function updateDesiredStatsOptions() {
     const statType = document.getElementById('statType').value;
 
     if (itemType === 'weapon' || itemType === 'secondary' || itemType === 'emblem') {
-        addCommonWSEOptions(itemLevel, desiredTier);
+        addCommonWSEOptions(itemLevel, desiredTier, itemType);
         removeNormalStatOptions();
         if (itemType !== 'emblem') {
             addCommonSEOptions(itemLevel, desiredTier);


### PR DESCRIPTION
This PR makes 3 changes:

1. Adds the existing attack/boss/IED line options to emblems and epic potential tier but with the boss text removed since it's a valid option.
2. Adds support for boss+IED lines to the probability code (but I didn't end up using it).
3. Adds new attack + attack/boss/IED lines (see screenshots).

Attack + any lines for weapon:
<img width="569" alt="image" src="https://github.com/brendonmay/brendonmay.github.io/assets/11654191/67b86360-3f0e-4682-b8e8-ba55b2c28300">

For emblem:
<img width="577" alt="image" src="https://github.com/brendonmay/brendonmay.github.io/assets/11654191/6d32346b-28df-4857-bfaa-a4587bb845e6">

In epic potential:
<img width="572" alt="image" src="https://github.com/brendonmay/brendonmay.github.io/assets/11654191/911fdc71-10bf-4442-9ca9-0a149da36756">
