### PR TITLE
Update Cubing Calc Max HP lines

### DIFF
--- a/cubingCalculator/getProbability.js
+++ b/cubingCalculator/getProbability.js
@@ -351,7 +351,7 @@ function convertCubeDataForLevel(cubeData, itemLevel) {
 
     let adjustedCubeData = {};
     const affected_categories = [CATEGORY.STR_PERC, CATEGORY.LUK_PERC, CATEGORY.DEX_PERC, CATEGORY.INT_PERC,
-        CATEGORY.ALLSTATS_PERC, CATEGORY.ATT_PERC, CATEGORY.MATT_PERC];
+        CATEGORY.ALLSTATS_PERC, CATEGORY.ATT_PERC, CATEGORY.MATT_PERC, CATEGORY.MAXHP_PERC];
 
     console.groupCollapsed("Adjusted stats for lvl >=160")
     for (const line in cubeData) {

--- a/cubingCalculator/updateDesiredStatsOptions.js
+++ b/cubingCalculator/updateDesiredStatsOptions.js
@@ -41,7 +41,7 @@ function translateInputToObject(webInput) {
 }
 
 function getPrimeLineValue(itemLevel, desiredTier, type) {
-    const levelBonus = itemLevel >= 160 && !(type === "hp") ? 1 : 0;
+    const levelBonus = itemLevel >= 160 ? 1 : 0;
     const base = type === "allStat" ? 0 : 3;
 
     return base + (3 * desiredTier) + levelBonus;


### PR DESCRIPTION
This PR updates the cubing calc to account for the fact that Max HP lines no longer give 1% less stat than the others. Thanks to Scardor for letting me know about this.