### PR TITLE
Apply boom event to 21 stars and under only.

### DIFF
--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -311,7 +311,7 @@ function determineOutcome(current_star, rates, star_catch, boom_protect, five_te
             probability_boom = 0;
         }
     }
-    if (boom_event) {
+    if (boom_event && current_star <= 21) {
         //here
         probability_boom = probability_boom * 0.7
         probability_maintain = probability_maintain + probability_boom * 0.3


### PR DESCRIPTION
The 30% boom reduction event only applies to tapping at 21* and below.

https://maplestory.nexon.com/testworld/news/all/88
Sunday Maple effects related to Star Force enhancement are added.
- When strengthening Star Force below 21 stars, the destruction probability is reduced by 30%.