### PR TITLE
fix boom event calculation bug

### DIFF
--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -313,8 +313,8 @@ function determineOutcome(current_star, rates, star_catch, boom_protect, five_te
     }
     if (boom_event && current_star <= 21) {
         //here
-        probability_boom = probability_boom * 0.7
         probability_maintain = probability_maintain + probability_boom * 0.3
+        probability_boom = probability_boom * 0.7
 
         //success + maintain + boom = 1
         //sucess + maintain + boom * (0.7 +0.3) = 1


### PR DESCRIPTION
There is an mathematical error in calculating the 30% boom reduction event.

https://github.com/brendonmay/brendonmay.github.io/blob/71648c6e5e6da1a41312eddb86cc573eb34c5ce7/starforceCalculator/main.js#L314-L317

If we calculate `probability_boom = probability_boom * 0.7` first, then the second line `probability_maintain + probability_boom * 0.3` equals `probability_maintain + old_probability_boom * 0.7 * 0.3`.

For example, assuming `old_probability_boom` is $0.3$, then `probability_boom` is $0.3 \times 0.7 = 0.21$, which decreases by $0.09$. `probability_maintain` will increase by $old\\_probability\\_boom \times 0.3 = 0.3 \times 0.3 = 0.09$ rather than $probability\\_boom \times 0.3 = 0.21 \times 0.3$.