### PR TITLE
fix boom protection bugs

### DIFF
--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -320,7 +320,11 @@ function determineOutcome(current_star, rates, star_catch, boom_protect, five_te
         //sucess + maintain + boom * (0.7 +0.3) = 1
     }
     if (boom_protect && current_star <= 16 && server != 'kms') { //boom protection enabled non-KMS
-        probability_decrease = probability_decrease + probability_boom;
+        if (probability_decrease > 0) {
+            probability_decrease = probability_decrease + probability_boom;
+        } else {
+            probability_maintain = probability_maintain + probability_boom;
+        }
         probability_boom = 0;
     }
     if (boom_protect && current_star <= 17 && server == 'kms') { //boom protection enabled KMS


### PR DESCRIPTION
https://github.com/brendonmay/brendonmay.github.io/blob/461c0c7934f4a02e97c06e484bd0f0a3314dd1b2/starforceCalculator/main.js#L322-L325

For non-KMS server, without boom protection enabled, assuming that `cur_star` is 15, then we will get:

- `probability_decrease` is 0%
- `probability_maintance` is 67.9%
- `probability_boom` is 2.1%

If we enable boom protection, the `probability_boom` will be converted to `probability_maintance` instead of `probability_decrease`, otherwise there would be a 2.1% chance to decrease to 14.