### PR TITLE
Update boom_protect condition in kms

### DIFF
--- a/starforceCalculator/main.js
+++ b/starforceCalculator/main.js
@@ -105,7 +105,7 @@ function attemptCost(current_star, item_level, boom_protect, thirty_off, sauna, 
     if (server == "kms") {
         //here
 
-        if (boom_protect) {
+        if (boom_protect && !(five_ten_fifteen && current_star == 15)) {
             multiplier = multiplier + getSafeguardMultiplierIncrease(current_star, sauna, server);
         }
 


### PR DESCRIPTION
`five_ten_fifteen` event was now available in kms.

`determineOutcome` was changed in https://github.com/brendonmay/brendonmay.github.io/commit/2487962569b13c9bb03ebccb69a836c62917b3fb . But `attempCost` hasn't been changed.

https://github.com/brendonmay/brendonmay.github.io/blob/3a17297429f324a2d6eeed2bbc0f340799d05714/starforceCalculator/main.js#L105-L119